### PR TITLE
Fix article containing wide pre blocks rendering on mobile devices.

### DIFF
--- a/app/application.less
+++ b/app/application.less
@@ -275,7 +275,6 @@ article.pages {
   pre {
     code {
       border-radius: 0;
-      white-space: pre;
     }
 
     @media (max-width: @phone-width) {


### PR DESCRIPTION
Before
![selection_006](https://cloud.githubusercontent.com/assets/2089269/10816419/03e80968-7e33-11e5-8197-b4ecfa894ef2.png)
After
![selection_007](https://cloud.githubusercontent.com/assets/2089269/10816422/067af21c-7e33-11e5-89e7-adef7b0ddc60.png)
